### PR TITLE
Hash password and add `createUser` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Disconnect from the DDP server.
 * [Meteor.loginWithPassword](http://docs.meteor.com/#/full/meteor_loginwithpassword) (Please note that user is auto-resigned in - like in Meteor Web applications - thanks to React Native AsyncStorage.)
 * [Meteor.logout](http://docs.meteor.com/#/full/meteor_logout)
 * [Meteor.call](http://docs.meteor.com/#/full/meteor_call)
-
+* [Accounts.createUser](http://docs.meteor.com/#/full/accounts_createuser)
 
 ## Meteor.ddp
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,10 @@ export function uniqueId () {
 export function contains (array, element) {
     return array.indexOf(element) !== -1;
 }
+
+export function hashPassword (password) {
+  return {
+    digest: SHA256(password).toString(),
+    algorithm: "sha-256"
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,7 @@ export function uniqueId () {
 export function contains (array, element) {
     return array.indexOf(element) !== -1;
 }
+
+export function trimString (str) {
+  return str.replace(/^\s+|\s+$/gm,'');
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,5 +8,6 @@ export function contains (array, element) {
 }
 
 export function trimString (str) {
+  if (typeof str !== 'string') return;
   return str.replace(/^\s+|\s+$/gm,'');
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,3 @@ export function uniqueId () {
 export function contains (array, element) {
     return array.indexOf(element) !== -1;
 }
-
-export function trimString (str) {
-  if (typeof str !== 'string') return;
-  return str.replace(/^\s+|\s+$/gm,'');
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+import SHA256 from 'crypto-js/sha256';
+
 var i = 0;
 export function uniqueId () {
     return (i++).toString();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/inProgress-team/react-native-meteor#readme",
   "dependencies": {
+    "crypto-js": "^3.1.6",
     "ejson": "^2.1.2",
     "minimongo-cache": "0.0.48",
     "react-mixin": "^3.0.3",

--- a/src/Accounts.js
+++ b/src/Accounts.js
@@ -1,0 +1,22 @@
+import User from './User';
+import Meteor from './Meteor';
+import { hashPassword } from '../utils';
+
+export default {
+  createUser(options, callback) {
+    if (options.username) options.username = options.username;
+    if (options.email) options.email = options.email;
+
+    // Replace password with the hashed password.
+    options.password = hashPassword(options.password);
+
+    User._startLoggingIn();
+    Meteor.call("createUser", options, (err, result)=>{
+      User._endLoggingIn();
+
+      User._handleLoginCallback(err, result);
+
+      typeof callback == 'function' && callback(err);
+    });
+  },
+}

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -9,7 +9,9 @@ import Mixin from './Mixin';
 import User from './User';
 import ListView from './ListView';
 
-module.exports = {
+export Accounts from './Accounts';
+
+export default {
   MeteorListView: ListView,
   connectMeteor(reactClass) {
     return reactMixin.onClass(reactClass, Mixin);

--- a/src/User.js
+++ b/src/User.js
@@ -1,10 +1,16 @@
 import { AsyncStorage } from 'react-native';
 import SHA256 from 'crypto-js/sha256';
 
-import { trimString } from '../lib/utils';
 import Data from './Data';
 
 const TOKEN_KEY = 'reactnativemeteor_usertoken';
+
+const hashPassword = (password) => {
+  return {
+    digest: SHA256(password).toString(),
+    algorithm: "sha-256"
+  }
+}
 
 module.exports = {
   user() {
@@ -21,39 +27,35 @@ module.exports = {
   logout(callback) {
     this.call("logout", function(err) {
       AsyncStorage.removeItem(TOKEN_KEY);
-      if(typeof callback == 'function') {
-        callback(err);
-      }
+      typeof callback == 'function' && callback(err);
     });
   },
   loginWithPassword(selector, password, callback) {
     if (typeof selector === 'string') {
       if (selector.indexOf('@') === -1)
-        selector = {username: trimString(selector)};
+        selector = {username: selector};
       else
-        selector = {email: trimString(selector)};
+        selector = {email: selector};
     }
 
     this._startLoggingIn();
     this.call("login", {
         user: selector,
-        password: SHA256(trimString(password)).toString()
+        password: hashPassword(password)
     }, (err, result)=>{
       this._endLoggingIn();
 
       this._handleLoginCallback(err, result);
 
-      if(typeof callback == 'function') {
-        callback(err)
-      }
+      typeof callback == 'function' && callback(err);
     });
   },
   createUser(options, callback) {
-    if (options.username) options.username = trimString(options.username);
-    if (options.email) options.email = trimString(options.email);
+    if (options.username) options.username = options.username;
+    if (options.email) options.email = options.email;
 
     // Replace password with the hashed password.
-    options.password = SHA256(trimString(options.password)).toString();
+    options.password = hashPassword(options.password);
 
     this._startLoggingIn();
     this.call("createUser", options, (err, result)=>{

--- a/src/User.js
+++ b/src/User.js
@@ -48,6 +48,24 @@ module.exports = {
       }
     });
   },
+  createUser(options, callback) {
+    if (options.username) options.username = trimString(options.username);
+    if (options.email) options.email = trimString(options.email);
+
+    // Replace password with the hashed password.
+    options.password = SHA256(options.password).toString();
+
+    this._startLoggingIn();
+    this.call("createUser", options, (err, result)=>{
+      this._endLoggingIn();
+
+      this._handleLoginCallback(err, result);
+
+      if(typeof callback == 'function') {
+        callback(err)
+      }
+    });
+  },
   _startLoggingIn() {
     this._isLoggingIn = true;
     Data._notifyLoggingIn();

--- a/src/User.js
+++ b/src/User.js
@@ -1,5 +1,4 @@
 import { AsyncStorage } from 'react-native';
-import SHA256 from 'crypto-js/sha256';
 
 import Data from './Data';
 import { hashPassword } from '../utils';

--- a/src/User.js
+++ b/src/User.js
@@ -1,5 +1,7 @@
 import { AsyncStorage } from 'react-native';
+import SHA256 from 'crypto-js/sha256';
 
+import { trimString } from '../lib/utils';
 import Data from './Data';
 
 const TOKEN_KEY = 'reactnativemeteor_usertoken';
@@ -27,15 +29,15 @@ module.exports = {
   loginWithPassword(selector, password, callback) {
     if (typeof selector === 'string') {
       if (selector.indexOf('@') === -1)
-        selector = {username: selector};
+        selector = {username: trimString(selector)};
       else
-        selector = {email: selector};
+        selector = {email: trimString(selector)};
     }
 
     this._startLoggingIn();
     this.call("login", {
         user: selector,
-        password: password
+        password: SHA256(password).toString()
     }, (err, result)=>{
       this._endLoggingIn();
 

--- a/src/User.js
+++ b/src/User.js
@@ -2,15 +2,9 @@ import { AsyncStorage } from 'react-native';
 import SHA256 from 'crypto-js/sha256';
 
 import Data from './Data';
+import { hashPassword } from '../utils';
 
 const TOKEN_KEY = 'reactnativemeteor_usertoken';
-
-const hashPassword = (password) => {
-  return {
-    digest: SHA256(password).toString(),
-    algorithm: "sha-256"
-  }
-}
 
 module.exports = {
   user() {
@@ -48,24 +42,6 @@ module.exports = {
       this._handleLoginCallback(err, result);
 
       typeof callback == 'function' && callback(err);
-    });
-  },
-  createUser(options, callback) {
-    if (options.username) options.username = options.username;
-    if (options.email) options.email = options.email;
-
-    // Replace password with the hashed password.
-    options.password = hashPassword(options.password);
-
-    this._startLoggingIn();
-    this.call("createUser", options, (err, result)=>{
-      this._endLoggingIn();
-
-      this._handleLoginCallback(err, result);
-
-      if(typeof callback == 'function') {
-        callback(err)
-      }
     });
   },
   _startLoggingIn() {

--- a/src/User.js
+++ b/src/User.js
@@ -37,7 +37,7 @@ module.exports = {
     this._startLoggingIn();
     this.call("login", {
         user: selector,
-        password: SHA256(password).toString()
+        password: SHA256(trimString(password)).toString()
     }, (err, result)=>{
       this._endLoggingIn();
 
@@ -53,7 +53,7 @@ module.exports = {
     if (options.email) options.email = trimString(options.email);
 
     // Replace password with the hashed password.
-    options.password = SHA256(options.password).toString();
+    options.password = SHA256(trimString(options.password)).toString();
 
     this._startLoggingIn();
     this.call("createUser", options, (err, result)=>{


### PR DESCRIPTION
Thanks for your work on this! It's looking great :smile:.

Thought I would lend hand an hash passwords before we send them over the wire. I also implemented [`createUser`](http://docs.meteor.com/#/full/accounts_createuser) so a user can now call `Meteor.createUser(options)`.

Let me know if there's anything you would like me to do prior to merging. Let me know if I can help you out in any other way! I've been looking for a replacement to the ddp client in my [Meteor + React Native boilerplate](https://github.com/spencercarli/react-native-meteor-boilerplate) and this is looking like it would very nicely fit that bill.

## TODO
- [x] Add `digest` field to the password login
- [x] Use `typeof callback == 'function' && callback(err);` for more concise code
- [x] Add `createUser` to the README
- [x] Remove trimInputs to match Meteor code
- [x] Create and export `Accounts` and put createUser on that. 

> We should do import Meteor, { Accounts } from 'react-native-meteor';
