### PR TITLE
Add a check to ensure collection exist before DDP tries to remove or …

### DIFF
--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -148,11 +148,11 @@ module.exports = {
     });
 
     Data.ddp.on("changed", message => {
-      Data.db[message.collection].upsert({_id: message.id, ...message.fields});
+      Data.db[message.collection] && Data.db[message.collection].upsert({_id: message.id, ...message.fields});
     });
 
     Data.ddp.on("removed", message => {
-      Data.db[message.collection].del(message.id);
+      Data.db[message.collection] && Data.db[message.collection].del(message.id);
     });
     Data.ddp.on("result", message => {
       const call = Data.calls.find(call=>call.id==message.id);


### PR DESCRIPTION
Was getting undefined error for some collections, when DDP 'remove' was triggered before adding for some reason (could be because of multiple subscriptions). Strange issue, but happened for some users and resulted in app crash.