### PR TITLE
Enhance waitDdpReady for performance

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -1,10 +1,20 @@
 import ReactNative from 'react-native';
 import minimongo from 'minimongo-cache';
+import Trackr from 'trackr';
+import { InteractionManager } from 'react-native';
 process.nextTick = setImmediate;
 
 const db = new minimongo();
 db.debug = false;
 db.batchedUpdates = ReactNative.unstable_batchedUpdates;
+
+function runAfterOtherComputations(fn){
+  InteractionManager.runAfterInteractions(() => {
+    Trackr.afterFlush(() => {
+      fn();
+    });
+  });
+}
 
 export default {
   _endpoint: null,
@@ -22,9 +32,9 @@ export default {
     if(this.ddp) {
       cb();
     } else {
-      setTimeout(()=>{
+      runAfterInteractions(()=>{
         this.waitDdpReady(cb);
-      }, 10);
+      });
     }
   },
 


### PR DESCRIPTION
This ends up to cause the same enhancement as https://github.com/Astrocoders/rn-meteor-containerize provides with much less code.

As @Tim-M pointed in #93, [workers](https://www.npmjs.com/package/react-native-workers) could also provide more performance but for now I'm just going to stick a bit researching about them.

For now the current improvement guarantees that the Mixin will let any on going animations or Tracker invalidations finish first before booting up.