### PR TITLE
Remove onerror callback from the raw socket

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -47,24 +47,6 @@ export default class Socket extends EventEmitter {
             this.closing = false;
         };
         /*
-        *   Calls to `onerror` trigger the `close` event on the `Socket`
-        *   instance, and cause the `rawSocket` object to be disposed of.
-        *   Since it's not clear what conditions could cause the error and if
-        *   it's possible to recover from it, we prefer to always close the
-        *   connection (if it isn't already) and dispose of the socket object.
-        */
-        this.rawSocket.onerror = () => {
-            // It's not clear what the socket lifecycle is when errors occurr.
-            // Hence, to avoid the `close` event to be emitted twice, before
-            // manually closing the socket we de-register the `onclose`
-            // callback.
-            delete this.rawSocket.onclose;
-            // Safe to perform even if the socket is already closed
-            this.rawSocket.close();
-            this.rawSocket = null;
-            this.emit("close");
-        };
-        /*
         *   Calls to `onmessage` trigger a `message:in` event on the `Socket`
         *   instance only once the message (first parameter to `onmessage`) has
         *   been successfully parsed into a javascript object.


### PR DESCRIPTION
If we look at [these lines](https://github.com/facebook/react-native/blob/c32ab7e60820eeca4f13722e652251b3e67d795e/Libraries/WebSocket/WebSocket.js#L188-L201) in react-native WebSocket class, it seems that both `close` and `error` events are dispatched on socket failure and that the call to the `close()` method for the socket instance is already handled there, which makes the `onerror` callback on rawSocket completely irrelevant. 

Plus, I've seen cases where both `onclose` and `onerror` are callback are executed on socket failure, despise the rawSocket nullification, which leads to hazardous behavior.