### PR TITLE
Update Mixin.js

### DIFF
--- a/src/components/Mixin.js
+++ b/src/components/Mixin.js
@@ -38,13 +38,16 @@ export default {
         // See https://github.com/facebook/react/issues/3398.
         this.props = nextProps;
         this.state = nextState;
-        newData = this._meteorDataManager.calculateData();
+        if (this._meteorDataManager) {
+          newData = this._meteorDataManager.calculateData();
+        }
       } finally {
         this.props = saveProps;
         this.state = saveState;
       }
-
-      this._meteorDataManager.updateData(newData);
+      if (this._meteorDataManager && newData) {
+        this._meteorDataManager.updateData(newData);
+      }
     }
 
   },


### PR DESCRIPTION
There is no 'catch' in the 'try' 'catch' method.  `this._meteorDataManager` was undefined halting loading of my app. This change made it work. There may be a better way.