### PR TITLE
Change update method to find, modify and upsert in to minimongo befor…

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -115,6 +115,16 @@ export class Collection {
       reason: `Item not found in collection ${this._name} with id ${id}`
     });
 
+    let item = this._collection.findOne({ _id: id });
+
+    // update the item fileds according to $ operators
+    Object.keys(modifier.$set).forEach((key) => {
+      item[key] = modifier.$set[key];
+    });
+
+    // change mini mongo for optimize UI changes
+    this._collection.upsert(item);
+    
     Data.waitDdpConnected(()=>{
       call(`/${this._name}/update`, {_id: id}, modifier, err => {
         if(err) {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -115,15 +115,8 @@ export class Collection {
       reason: `Item not found in collection ${this._name} with id ${id}`
     });
 
-    let item = this._collection.findOne({ _id: id });
-
-    // update the item fileds according to $ operators
-    Object.keys(modifier.$set).forEach((key) => {
-      item[key] = modifier.$set[key];
-    });
-
     // change mini mongo for optimize UI changes
-    this._collection.upsert(item);
+    this._collection.upsert({ _id: id, ...modifier.$set });
     
     Data.waitDdpConnected(()=>{
       call(`/${this._name}/update`, {_id: id}, modifier, err => {


### PR DESCRIPTION
According to the [API docs](https://github.com/inProgress-team/react-native-meteor#additionals-collection-methods) Meteor.collection(collectionName, options).update(id, modifier, [options], [callback]) method doesn't work offline.
I did some simple changes in Collection.js to upsert the modified document in to minimongo before sending ddp call.
This supports for any number of $set modifiers.

We can test, improve this for more scenarios and this can be the solution to a **TODO next** in [#33](https://github.com/inProgress-team/react-native-meteor/issues/33) 