### PR TITLE
Fix error 'db.batchUpdates undefined is not a function'. Issue #183.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "react-komposer": "^1.8.0",
     "react-mixin": "^3.0.3",
     "trackr": "^2.0.2",
-    "wolfy87-eventemitter": "^4.3.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "wolfy87-eventemitter": "^4.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",

--- a/src/Data.js
+++ b/src/Data.js
@@ -1,4 +1,4 @@
-import ReactNative from 'react-native';
+import ReactNative from 'react-native/Libraries/Renderer/src/renderers/native/ReactNative';
 import minimongo from 'minimongo-cache';
 import Trackr from 'trackr';
 import { InteractionManager } from 'react-native';


### PR DESCRIPTION
Solution for:
https://github.com/inProgress-team/react-native-meteor/issues/183

Exposing of _batchUpdates from core ReactNative component was deprecated.
Sourcing _batchedUpdates from renderer.

Since there is no activity in https://github.com/facebook/react-native/issues/14490 which was posted to RN repo for this matter I think this is the best solution for now.