### PR TITLE
Fix import for RN 0.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
     "mocha": "^2.4.5",
     "mock-socket": "^2.0.0",
     "sinon": "^1.17.3"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "^0.46.0"
   }
 }

--- a/src/Data.js
+++ b/src/Data.js
@@ -1,4 +1,4 @@
-import ReactNative from 'react-native/Libraries/Renderer/src/renderers/native/ReactNative';
+import ReactNative from 'react-native/Libraries/Renderer/shims/ReactNative';
 import minimongo from 'minimongo-cache';
 import Trackr from 'trackr';
 import { InteractionManager } from 'react-native';


### PR DESCRIPTION
The import path has changed with RN 0.46.

⚠️  Breaking change with RN < 0.46.

cc @Nauzer.