### PR TITLE
Add peerDependencies on RN <= 0.45 and React

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
     "mocha": "^2.4.5",
     "mock-socket": "^2.0.0",
     "sinon": "^1.17.3"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "<=0.45.x" 
   }
 }


### PR DESCRIPTION
For release `1.0.6` before introducing breaking changes in `1.1.0`.

cc @Nauzer 