### PR TITLE
Change isPlainObject to match the functionality of Meteor.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,13 +1,14 @@
 import SHA256 from 'crypto-js/sha256';
+import EJSON from 'ejson';
 import _ from "underscore";
 
 var i = 0;
 export function uniqueId () {
-    return (i++).toString();
+  return (i++).toString();
 }
 
 export function contains (array, element) {
-    return array.indexOf(element) !== -1;
+  return array.indexOf(element) !== -1;
 }
 
 export function hashPassword (password) {
@@ -17,68 +18,16 @@ export function hashPassword (password) {
   }
 }
 
-
-//From Meteor core
-var class2type = {};
-
-var toString = class2type.toString;
-
-var hasOwn = class2type.hasOwnProperty;
-
-var support = {};
-
-// Populate the class2type map
-_.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(name, i) {
-  class2type[ "[object " + name + "]" ] = name.toLowerCase();
-});
-
-function type( obj ) {
-  if ( obj == null ) {
-    return obj + "";
-  }
-  return typeof obj === "object" || typeof obj === "function" ?
-    class2type[ toString.call(obj) ] || "object" :
-    typeof obj;
-}
-
-function isWindow( obj ) {
-  /* jshint eqeqeq: false */
-  return obj != null && obj == obj.window;
-}
-
 export function isPlainObject ( obj ) {
-  var key;
-
-  // Must be an Object.
-  // Because of IE, we also have to check the presence of the constructor property.
-  // Make sure that DOM nodes and window objects don't pass through, as well
-  if ( !obj || type(obj) !== "object" || obj.nodeType || isWindow( obj ) ) {
-    return false;
-  }
-
-  try {
-    // Not own constructor property must be Object
-    if ( obj.constructor &&
-         !hasOwn.call(obj, "constructor") &&
-         !hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
-      return false;
-    }
-  } catch ( e ) {
-    // IE8,9 Will throw exceptions on certain host objects #9897
-    return false;
-  }
-
-  // Support: IE<9
-  // Handle iteration over inherited properties before own properties.
-  if ( support.ownLast ) {
-    for ( key in obj ) {
-      return hasOwn.call( obj, key );
-    }
-  }
-
-  // Own properties are enumerated firstly, so to speed up,
-  // if last one is own, then all properties are own.
-  for ( key in obj ) {}
-
-  return key === undefined || hasOwn.call( obj, key );
+  return !!obj
+         && !(typeof v === 'number')
+         && !(typeof v === 'string')
+         && !(typeof v === 'boolean')
+         && !(Array.isArray(v))
+         && !(v === null)
+         && !(v instanceof RegExp)
+         && !(typeof v === 'function')
+         && !(v instanceof Date)
+         && !(EJSON.isBinary(v))
+         && !(v instanceof MongoID.ObjectID)
 };


### PR DESCRIPTION
The `isPlainObject` function is only used to check whether an object returned from a collection transformation is valid.

The actual function used is defined in meteor here: https://github.com/meteor/meteor/blob/3e4accda7cf3f/packages/minimongo/local_collection.js#L1104 which in turn calls this: https://github.com/meteor/meteor/blob/3e4accda7cf3f/packages/minimongo/matcher.js#L133

Since we don't care about classifying the other types, I've compressed the logic.

I care about this because my transform returns an object with a constructor which works with meteor but currently not react-native-meteor.