### PR TITLE
Fixed deprecated React.createClass() to a new module createReactClass()

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/inProgress-team/react-native-meteor#readme",
   "dependencies": {
     "base-64": "^0.1.0",
+    "create-react-class": "^15.6.0",
     "crypto-js": "^3.1.6",
     "ejson": "^2.1.2",
     "minimongo-cache": "0.0.48",

--- a/src/components/createContainer.js
+++ b/src/components/createContainer.js
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import createReactClass from 'createReactClass';
 
 import Mixin from './Mixin';
 
@@ -18,7 +19,7 @@ export default function createContainer(options = {}, Component) {
     getMeteorData
   } = expandedOptions;
 
-  return React.createClass({
+  return createReactClass({
     displayName: 'MeteorDataContainer',
     mixins: [Mixin],
     getMeteorData() {

--- a/src/components/createContainer.js
+++ b/src/components/createContainer.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import createReactClass from 'createReactClass';
+import createReactClass from 'create-react-class';
 
 import Mixin from './Mixin';
 

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -25,7 +25,7 @@ module.exports = {
   logout(callback) {
     call("logout", err => {
       this.handleLogout();
-      this.connect();
+      //this.connect();
 
       typeof callback == 'function' && callback(err);
     });

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -25,7 +25,7 @@ module.exports = {
   logout(callback) {
     call("logout", err => {
       this.handleLogout();
-      //this.connect();
+      this.connect();
 
       typeof callback == 'function' && callback(err);
     });


### PR DESCRIPTION
React has deprecated React.createClass() function but they separated it to a new module create-react-class for those using mixins. Just changed the function call from the deprecated function to the new module