### PR TITLE
mini-mongo cache clear on connect to remove stale documents

### DIFF
--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -88,7 +88,7 @@ module.exports = {
       ...options
     });
 
-    NetInfo.isConnected.addEventListener('change', isConnected=>{
+    NetInfo.isConnected.addEventListener('connectionChange', isConnected=>{
       if(isConnected && Data.ddp.autoReconnect) {
         Data.ddp.connect();
       }

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -97,6 +97,13 @@ module.exports = {
 
     Data.ddp.on("connected", ()=>{
 
+      // Clear the collections of any stale data in case this is a reconnect
+      if (Data.db && Data.db.collections) {
+        for (var collection in Data.db.collections) {
+          Data.db[collection].remove({});
+        }
+      }
+
       Data.notify('change');
 
       console.info("Connected to DDP server.");


### PR DESCRIPTION
Resolves #233. Clear mini-mongo cache after connection is established before subscriptions are renewed. This is to handle cases of disconnect and reconnect and deleted documents on server in that window.

Also resolving #272 