### PR TITLE
Adds celar() and remove() method for reactive-dict package

### DIFF
--- a/src/ReactiveDict.js
+++ b/src/ReactiveDict.js
@@ -21,6 +21,17 @@ export default class ReactiveDict {
       }
     }
   }
+   clear() {
+    var oldKeys = this.keys;
+    this.keys = {};
+    Data.notify('change');
+  }
+  delete(key) {
+    if (this.keys[key]) {
+      delete this.keys[key];
+      Data.notify('change');
+    }
+  }
   set(keyOrObject, value) {
     if (typeof keyOrObject === 'object' && value === undefined) {
       this._setObject(keyOrObject);

--- a/src/ReactiveDict.js
+++ b/src/ReactiveDict.js
@@ -21,8 +21,7 @@ export default class ReactiveDict {
       }
     }
   }
-   clear() {
-    var oldKeys = this.keys;
+  clear() {
     this.keys = {};
     Data.notify('change');
   }


### PR DESCRIPTION
These two methods exist in the original package and quite handy. Let me know if this can be merged or if you'd like some modification?