### PR TITLE
Handle $unset in "changed" event

### DIFF
--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -153,11 +153,19 @@ module.exports = {
     });
 
     Data.ddp.on('changed', message => {
-      Data.db[message.collection] &&
-        Data.db[message.collection].upsert({
-          _id: message.id,
-          ...message.fields,
-        });
+		const unset = {};
+		if (message.cleared) {
+		  message.cleared.forEach(field => {
+			unset[field] = null;
+		  });
+		}
+
+		Data.db[message.collection] &&
+		  Data.db[message.collection].upsert({
+			_id: message.id,
+			...message.fields,
+			...unset,
+		  });
     });
 
     Data.ddp.on('removed', message => {

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -153,19 +153,19 @@ module.exports = {
     });
 
     Data.ddp.on('changed', message => {
-		const unset = {};
-		if (message.cleared) {
-		  message.cleared.forEach(field => {
-			unset[field] = null;
-		  });
-		}
+      const unset = {};
+      if (message.cleared) {
+        message.cleared.forEach(field => {
+          unset[field] = null;
+        });
+      }
 
-		Data.db[message.collection] &&
-		  Data.db[message.collection].upsert({
-			_id: message.id,
-			...message.fields,
-			...unset,
-		  });
+      Data.db[message.collection] &&
+        Data.db[message.collection].upsert({
+          _id: message.id,
+          ...message.fields,
+          ...unset,
+        });
     });
 
     Data.ddp.on('removed', message => {


### PR DESCRIPTION
For now, `$unset` in update messages are ignored. I added some code to handle `$unset`, by setting the key's value to `null`. 