### PR TITLE
Stop breaking user's session if login fails once.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/inProgress-team/react-native-meteor#readme",
   "dependencies": {
+    "@react-native-community/netinfo": "^4.6.1",
     "base-64": "^0.1.0",
     "crypto-js": "^3.1.6",
     "ejson": "^2.1.2",

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -1,4 +1,5 @@
-import { NetInfo, Platform, View } from 'react-native';
+import { Platform, View } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 
 import reactMixin from 'react-mixin';
 import Trackr from 'trackr';

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -95,7 +95,8 @@ module.exports = {
       Data.notify('onLogin');
     } else {
       Data.notify('onLoginFailure');
-      this.handleLogout();
+      console.warn('login failed, make sure the server you are accessing is correct');
+      //this.handleLogout();
     }
     Data.notify('change');
   },

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -53,7 +53,7 @@ module.exports = {
 
         this._handleLoginCallback(err, result);
 
-        typeof callback == 'function' && callback(err);
+        typeof callback == 'function' && callback(err, result);
       }
     );
   },

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -75,7 +75,7 @@ module.exports = {
 
       this._handleLoginCallback(err, result);
 
-      typeof callback == 'function' && callback(err);
+      typeof callback == 'function' && callback(err, result);
     });
   },
   _startLoggingIn() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@react-native-community/netinfo@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.6.1.tgz#09960b49217d555e54144f54e63485fe55d673ad"
+  integrity sha512-RIcrNzVnkes6/d5jFprce8i6ruUO9+/FVZZgejlu/TSnysyFXHNJKgcIqxbKx+7XfQxfjrCGeCvsfYxrFrU0zw==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
I noticed in one of my projects that users mysteriously got logged out. This happened especially to users with bad network connectivity.

When looking into the code, I noticed that the _handleLoginCallback function clears the loginToken if login fails. Is there a clear reason as to why this behaviour was programmed? I removed it for my project and would propose merging this into the next release if there is no clear reason to remove login tokens at login failure.