### PR TITLE
Use @react-native-community/netinfo (Fix for RN >=0.60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Since RN 0.26.0 you have to use ws or wss protocol to connect to your meteor ser
 
 It is recommended to always use the latest version of react-native-meteor compatible with your RN version:
 
-* For RN > 0.49, use `react-native-meteor@latest`
+* For RN > 0.60 use `react-native-meteor@latest`
+* For RN > 0.49 & < 0.60, use `react-native-meteor@1.4.x`
 * For RN > 0.45, use `react-native-meteor@1.1.x`
 * For RN = 0.45, use `react-native-meteor@1.0.6`
 * For RN < 0.45, you can use version `react-native-meteor@1.0.3` in case or problems.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "trackr": "^2.0.2",
     "underscore": "^1.8.3",
     "wolfy87-eventemitter": "^4.3.0",
-    "@react-native-community/netinfo":"^4.6.1"
+    "@react-native-community/netinfo":"^5.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-mixin": "^3.0.3",
     "trackr": "^2.0.2",
     "underscore": "^1.8.3",
-    "wolfy87-eventemitter": "^4.3.0"
+    "wolfy87-eventemitter": "^4.3.0",
+    "@react-native-community/netinfo":"^4.6.1"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "trackr": "^2.0.2",
     "underscore": "^1.8.3",
     "wolfy87-eventemitter": "^4.3.0",
-    "@react-native-community/netinfo":"^5.0.0"
+    "@react-native-community/netinfo":"^5.3.3"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
@@ -58,6 +58,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">= 0.49.0"
+    "react-native": ">= 0.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-meteor",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Full Meteor Client for React Native",
   "main": "src/Meteor.js",
   "scripts": {

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -1,4 +1,5 @@
-import { NetInfo, Platform, View } from 'react-native';
+import { Platform, View } from 'react-native';
+import NetInfo from "@react-native-community/netinfo";
 
 import reactMixin from 'react-mixin';
 import Trackr from 'trackr';

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -89,7 +89,7 @@ module.exports = {
       ...options,
     });
 
-    NetInfo.isConnected.addEventListener('connectionChange', isConnected => {
+    NetInfo.addEventListener(({type, isConnected, isInternetReachable, isWifiEnabled}) => {
       if (isConnected && Data.ddp.autoReconnect) {
         Data.ddp.connect();
       }


### PR DESCRIPTION
NetInfo is broken into a separate package and removed from React Native in versions >=0.60. Update the package to work with RN >=0.60.

Compatibility: I used the latest version of NetInfo, which is only compatible with RN >=0.60, so I bumped the package version and updated compatibility notes. I'm open to suggestions to allow it to still work with previous RN versions.